### PR TITLE
[SPARK] RewriteDataFiles - Escape special characters in table identifiers

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -61,6 +61,12 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement rewriteDataFiles");
   }
 
+  default RewriteDataFiles rewriteDataFiles(Table table, String fullIdentifier) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement rewriteDataFiles(Table, String)"
+    );
+  }
+
   /**
    * Instantiates an action to expire snapshots.
    */

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -57,6 +57,7 @@ public interface ActionsProvider {
   /**
    * Instantiates an action to rewrite data files.
    */
+  @Deprecated
   default RewriteDataFiles rewriteDataFiles(Table table) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement rewriteDataFiles");
   }

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -56,12 +56,16 @@ public interface ActionsProvider {
 
   /**
    * Instantiates an action to rewrite data files.
+   * @deprecated please use {@link #rewriteDataFiles(Table, String)}
    */
   @Deprecated
   default RewriteDataFiles rewriteDataFiles(Table table) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement rewriteDataFiles");
   }
 
+  /**
+   * Instantiates an action to rewrite data files.
+   */
   default RewriteDataFiles rewriteDataFiles(Table table, String fullIdentifier) {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement rewriteDataFiles(Table, String)"

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
@@ -74,6 +74,7 @@ public class IcebergSortCompactionBenchmark {
   private static final String[] NAMESPACE = new String[] {"default"};
   private static final String NAME = "sortbench";
   private static final Identifier IDENT = Identifier.of(NAMESPACE, NAME);
+  private static final String FULL_IDENT = Spark3Util.quotedFullIdentifier("spark_catalog", IDENT);
   private static final int NUM_FILES = 8;
   private static final long NUM_ROWS = 7500000L;
   private static final long UNIQUE_VALUES = NUM_ROWS / 4;
@@ -106,7 +107,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortInt() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -119,7 +120,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortInt2() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -133,7 +134,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortInt3() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -149,7 +150,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortInt4() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -165,7 +166,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortString() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -178,7 +179,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortFourColumns() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -194,7 +195,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void sortSixColumns() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .sort(SortOrder
             .builderFor(table().schema())
@@ -212,7 +213,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortInt() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("intCol")
         .execute();
@@ -222,7 +223,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortInt2() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("intCol", "intCol2")
         .execute();
@@ -232,7 +233,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortInt3() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("intCol", "intCol2", "intCol3")
         .execute();
@@ -242,7 +243,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortInt4() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("intCol", "intCol2", "intCol3", "intCol4")
         .execute();
@@ -252,7 +253,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortString() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("stringCol")
         .execute();
@@ -262,7 +263,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortFourColumns() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("stringCol", "intCol", "dateCol", "doubleCol")
         .execute();
@@ -272,7 +273,7 @@ public class IcebergSortCompactionBenchmark {
   @Threads(1)
   public void zSortSixColumns() {
     SparkActions.get()
-        .rewriteDataFiles(table())
+        .rewriteDataFiles(table(), FULL_IDENT)
         .option(BinPackStrategy.REWRITE_ALL, "true")
         .zOrder("stringCol", "intCol", "dateCol", "timestampCol", "doubleCol", "longCol")
         .execute();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -67,6 +67,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -747,6 +748,19 @@ public class Spark3Util {
 
   public static TableIdentifier identifierToTableIdentifier(Identifier identifier) {
     return TableIdentifier.of(Namespace.of(identifier.namespace()), identifier.name());
+  }
+
+  public static String quotedFullIdentifier(String catalogName, Identifier identifier) {
+    List<String> parts =
+        ImmutableList.<String>builder()
+            .add(catalogName)
+            .addAll(Arrays.asList(identifier.namespace()))
+            .add(identifier.name())
+            .build();
+
+    return CatalogV2Implicits.MultipartIdentifierHelper(
+        JavaConverters.asScalaIteratorConverter(parts.iterator()).asScala().toSeq()
+    ).quoted();
   }
 
   /**

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -87,6 +87,7 @@ public class BaseRewriteDataFilesSparkAction
   );
 
   private final Table table;
+  private final String fullIdentifier;
 
   private Expression filter = Expressions.alwaysTrue();
   private int maxConcurrentFileGroupRewrites;
@@ -96,9 +97,10 @@ public class BaseRewriteDataFilesSparkAction
   private RewriteJobOrder rewriteJobOrder;
   private RewriteStrategy strategy = null;
 
-  protected BaseRewriteDataFilesSparkAction(SparkSession spark, Table table) {
+  protected BaseRewriteDataFilesSparkAction(SparkSession spark, Table table, String fullIdentifier) {
     super(spark);
     this.table = table;
+    this.fullIdentifier = fullIdentifier;
   }
 
   @Override
@@ -428,7 +430,7 @@ public class BaseRewriteDataFilesSparkAction
   }
 
   private BinPackStrategy binPackStrategy() {
-    return new SparkBinPackStrategy(table, spark());
+    return new SparkBinPackStrategy(table, fullIdentifier, spark());
   }
 
   private SortStrategy sortStrategy() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -72,8 +72,8 @@ public class SparkActions implements ActionsProvider {
   }
 
   @Override
-  public RewriteDataFiles rewriteDataFiles(Table table) {
-    return new BaseRewriteDataFilesSparkAction(spark, table);
+  public RewriteDataFiles rewriteDataFiles(Table table, String fullIdentifier) {
+    return new BaseRewriteDataFilesSparkAction(spark, table, fullIdentifier);
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackStrategy.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackStrategy.java
@@ -38,12 +38,14 @@ import org.apache.spark.sql.internal.SQLConf;
 
 public class SparkBinPackStrategy extends BinPackStrategy {
   private final Table table;
+  private final String fullIdentifier;
   private final SparkSession spark;
   private final FileScanTaskSetManager manager = FileScanTaskSetManager.get();
   private final FileRewriteCoordinator rewriteCoordinator = FileRewriteCoordinator.get();
 
-  public SparkBinPackStrategy(Table table, SparkSession spark) {
+  public SparkBinPackStrategy(Table table, String fullIdentifier, SparkSession spark) {
     this.table = table;
+    this.fullIdentifier = fullIdentifier;
     this.spark = spark;
   }
 
@@ -66,7 +68,7 @@ public class SparkBinPackStrategy extends BinPackStrategy {
           .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID, groupID)
           .option(SparkReadOptions.SPLIT_SIZE, splitSize(inputFileSize(filesToRewrite)))
           .option(SparkReadOptions.FILE_OPEN_COST, "0")
-          .load(table.name());
+          .load(fullIdentifier);
 
       // All files within a file group are written with the same spec, so check the first
       boolean requiresRepartition = !filesToRewrite.get(0).spec().equals(table.spec());
@@ -82,7 +84,7 @@ public class SparkBinPackStrategy extends BinPackStrategy {
           .option(SparkWriteOptions.TARGET_FILE_SIZE_BYTES, writeMaxFileSize())
           .option(SparkWriteOptions.DISTRIBUTION_MODE, distributionMode)
           .mode("append")
-          .save(table.name());
+          .save(fullIdentifier);
 
       return rewriteCoordinator.fetchNewDataFiles(table, groupID);
     } finally {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -135,7 +135,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   private RewriteDataFiles basicRewrite(Table table) {
     // Always compact regardless of input files
     table.refresh();
-    return actions().rewriteDataFiles(table).option(BinPackStrategy.MIN_INPUT_FILES, "1");
+    return actions().rewriteDataFiles(table, tableLocation).option(BinPackStrategy.MIN_INPUT_FILES, "1");
   }
 
   @Test
@@ -258,7 +258,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     rowDelta.commit();
     table.refresh();
     List<Object[]> expectedRecords = currentData();
-    Result result = actions().rewriteDataFiles(table)
+    Result result = actions().rewriteDataFiles(table, tableLocation)
         // do not include any file based on bin pack file size configs
         .option(BinPackStrategy.MIN_FILE_SIZE_BYTES, "0")
         .option(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE - 1))
@@ -292,7 +292,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     rowDelta.commit();
     table.refresh();
     List<Object[]> expectedRecords = currentData();
-    Result result = actions().rewriteDataFiles(table)
+    Result result = actions().rewriteDataFiles(table, tableLocation)
         .option(BinPackStrategy.DELETE_FILE_THRESHOLD, "1")
         .execute();
     Assert.assertEquals("Action should rewrite 1 data files", 1, result.rewrittenDataFilesCount());
@@ -1122,13 +1122,17 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     Table table = createTable(1);
 
     AssertHelpers.assertThrows("Should be unable to set Strategy more than once", IllegalArgumentException.class,
-        "Cannot set strategy", () -> actions().rewriteDataFiles(table).binPack().sort());
+        "Cannot set strategy", () -> actions().rewriteDataFiles(table, tableLocation).binPack().sort());
 
     AssertHelpers.assertThrows("Should be unable to set Strategy more than once", IllegalArgumentException.class,
-        "Cannot set strategy", () -> actions().rewriteDataFiles(table).sort().binPack());
+        "Cannot set strategy", () -> actions().rewriteDataFiles(table, tableLocation).sort().binPack());
 
-    AssertHelpers.assertThrows("Should be unable to set Strategy more than once", IllegalArgumentException.class,
-        "Cannot set strategy", () -> actions().rewriteDataFiles(table).sort(SortOrder.unsorted()).binPack());
+    AssertHelpers.assertThrows(
+        "Should be unable to set Strategy more than once",
+        IllegalArgumentException.class,
+        "Cannot set strategy",
+        () ->
+            actions().rewriteDataFiles(table, tableLocation).sort(SortOrder.unsorted()).binPack());
   }
 
   @Test


### PR DESCRIPTION
Allows e.g. `db.special-chars`.`table.special-chars` when calling the RewriteDataFiles action or procedure, e.g.:

```sql
CALL system.rewrite_data_files(table => '`db.with-special`.`table.with-special`')
```

Currently this causes an exception as the full identifier (`<catalog>.<database>.<table>`) is stringified without any quoting.
```
IllegalArgumentException: Cannot parse path or identifier: dev.db.with-special.table.with-special
```
